### PR TITLE
Add decode tests, fix some off by 1s

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -6,7 +6,7 @@ use crate::{
 
 /// Represents all Telnet events supported by Nectar.
 /// See `<https://tools.ietf.org/html/rfc854>` for more information.
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum TelnetEvent {
     Character(u8),
     Message(String),

--- a/src/subnegotiation.rs
+++ b/src/subnegotiation.rs
@@ -27,11 +27,15 @@ impl SubnegotiationType {
                 for bytes in vec {
                     len += bytes.len();
                 }
-                len
+                // add one more for the subnegotation sub-option (i.e. CHARSET_REQUEST)
+                len + 1
             }
-            SubnegotiationType::CharsetAccepted(charset) => charset.len(),
-            SubnegotiationType::CharsetRejected => 0,
-            SubnegotiationType::CharsetTTableRejected => 0,
+            SubnegotiationType::CharsetAccepted(charset) => {
+                // add one more for the subnegotation sub-option (i.e. CHARSET_ACCEPTED)
+                charset.len() + 1
+            },
+            SubnegotiationType::CharsetRejected => 1,
+            SubnegotiationType::CharsetTTableRejected => 1,
             SubnegotiationType::Unknown(_, bytes) => bytes.len(),
         }
     }


### PR DESCRIPTION
Hi, I'm back.

This resolves some off-by-ones around subnegotiation lengths that were caught by the added tests. 😬

You can run the tests from the command line with `cargo test --lib ""`

sorry - #2 was off of a branch that had not been rebased off of this `main`.