### PR TITLE
add a TelnetEvent for raw messages

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -10,6 +10,7 @@ use crate::{
 pub enum TelnetEvent {
     Character(u8),
     Message(String),
+    RawMessage(String),
     Do(TelnetOption),
     Will(TelnetOption),
     Dont(TelnetOption),
@@ -24,6 +25,7 @@ impl TelnetEvent {
     pub fn len(&self) -> usize {
         match self {
             TelnetEvent::Message(message) => message.len(),
+            TelnetEvent::RawMessage(message) => message.len(),
             TelnetEvent::Subnegotiate(subnegotiation) => {
                 // the 5 is made up of the IAC SB, IAC SE, and the single byte
                 // option
@@ -47,7 +49,7 @@ impl TelnetEvent {
 impl From<TelnetEvent> for u8 {
     fn from(event: TelnetEvent) -> Self {
         match event {
-            TelnetEvent::Message(_) => 0x00,
+            TelnetEvent::Message(_) | TelnetEvent::RawMessage(_) => 0x00,
             TelnetEvent::Do(_) => DO,
             TelnetEvent::Will(_) => WILL,
             TelnetEvent::Dont(_) => DONT,

--- a/src/event.rs
+++ b/src/event.rs
@@ -9,7 +9,11 @@ use crate::{
 #[derive(Debug, PartialEq, Eq)]
 pub enum TelnetEvent {
     Character(u8),
+    /// A message that guarantees it ends with `\r\n`.
     Message(String),
+    /// A message that does not guarantee it ends with `\r\n`. Allows for
+    /// sending messages without enforced newlines. Used for outgoing
+    /// messages only.
     RawMessage(String),
     Do(TelnetOption),
     Will(TelnetOption),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -679,8 +679,8 @@ mod tests {
     }
 
     mod test_encode {
-        use crate::constants::ECHO;
         use super::*;
+        use crate::constants::ECHO;
 
         #[test]
         fn test_message() {
@@ -733,17 +733,27 @@ mod tests {
         #[test]
         fn test_sb_naws() {
             let (mut codec, mut buffer) = setup();
-            codec.encode(TelnetEvent::Subnegotiate(SubnegotiationType::WindowSize(80, 80)), &mut buffer).unwrap();
+            codec
+                .encode(
+                    TelnetEvent::Subnegotiate(SubnegotiationType::WindowSize(80, 80)),
+                    &mut buffer,
+                )
+                .unwrap();
             assert_eq!(buffer.as_ref(), &[IAC, SB, NAWS, 0x00, 0x50, 0x00, 0x50, IAC, SE]);
         }
 
         #[test]
         fn test_sb_charset_request() {
             let (mut codec, mut buffer) = setup();
-            codec.encode(TelnetEvent::Subnegotiate(SubnegotiationType::CharsetRequest(vec![
-                Bytes::from("UTF-8"),
-                Bytes::from("US-ASCII")
-            ])), &mut buffer).unwrap();
+            codec
+                .encode(
+                    TelnetEvent::Subnegotiate(SubnegotiationType::CharsetRequest(vec![
+                        Bytes::from("UTF-8"),
+                        Bytes::from("US-ASCII"),
+                    ])),
+                    &mut buffer,
+                )
+                .unwrap();
             assert_eq!(&buffer.as_ref()[0..=4], &[IAC, SB, CHARSET, CHARSET_REQUEST, b' ']);
             assert_eq!(&buffer.as_ref()[5..], b"UTF-8 US-ASCII\xFF\xF0" as &[u8]);
         }
@@ -751,7 +761,14 @@ mod tests {
         #[test]
         fn test_sb_charset_accepted() {
             let (mut codec, mut buffer) = setup();
-            codec.encode(TelnetEvent::Subnegotiate(SubnegotiationType::CharsetAccepted(Bytes::from("UTF-8"))), &mut buffer).unwrap();
+            codec
+                .encode(
+                    TelnetEvent::Subnegotiate(SubnegotiationType::CharsetAccepted(Bytes::from(
+                        "UTF-8",
+                    ))),
+                    &mut buffer,
+                )
+                .unwrap();
             assert_eq!(&buffer.as_ref()[0..=3], &[IAC, SB, CHARSET, CHARSET_ACCEPTED]);
             assert_eq!(&buffer.as_ref()[4..], b"UTF-8\xFF\xF0" as &[u8]);
         }
@@ -759,14 +776,21 @@ mod tests {
         #[test]
         fn test_sb_charset_rejected() {
             let (mut codec, mut buffer) = setup();
-            codec.encode(TelnetEvent::Subnegotiate(SubnegotiationType::CharsetRejected), &mut buffer).unwrap();
+            codec
+                .encode(TelnetEvent::Subnegotiate(SubnegotiationType::CharsetRejected), &mut buffer)
+                .unwrap();
             assert_eq!(buffer.as_ref(), &[IAC, SB, CHARSET, CHARSET_REJECTED, IAC, SE]);
         }
 
         #[test]
         fn test_sb_charset_ttable_rejected() {
             let (mut codec, mut buffer) = setup();
-            codec.encode(TelnetEvent::Subnegotiate(SubnegotiationType::CharsetTTableRejected), &mut buffer).unwrap();
+            codec
+                .encode(
+                    TelnetEvent::Subnegotiate(SubnegotiationType::CharsetTTableRejected),
+                    &mut buffer,
+                )
+                .unwrap();
             assert_eq!(buffer.as_ref(), &[IAC, SB, CHARSET, CHARSET_TTABLE_REJECTED, IAC, SE]);
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,6 +89,7 @@ impl Encoder<TelnetEvent> for TelnetCodec {
             TelnetEvent::Wont(option) => encode_negotiate(WONT, option, buffer),
             TelnetEvent::Subnegotiate(sb_type) => encode_sb(sb_type, buffer),
             TelnetEvent::Message(msg) => encode_message(msg, buffer),
+            TelnetEvent::RawMessage(msg) => encode_raw_message(msg, buffer),
             _ => {}
         }
 
@@ -405,7 +406,7 @@ fn encode_sb(sb: SubnegotiationType, buffer: &mut BytesMut) {
     }
 }
 
-fn encode_message(message: String, buffer: &mut BytesMut) {
+fn encode_raw_message(message: String, buffer: &mut BytesMut) {
     let bytes = Bytes::from(message);
     let mut bytes_buffer_size = bytes.len();
 
@@ -423,6 +424,10 @@ fn encode_message(message: String, buffer: &mut BytesMut) {
         }
         buffer.put_u8(*byte);
     }
+}
+
+fn encode_message(message: String, buffer: &mut BytesMut) {
+    encode_raw_message(message, buffer);
 
     if !buffer.ends_with(b"\r\n") {
         buffer.reserve(2);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -517,6 +517,22 @@ mod tests {
                 assert_eq!(buffer.as_ref(), &[b'y', b'e', b's']);
             }
 
+            #[test]
+            fn test_overflow() {
+                let (mut codec, mut buffer) = setup();
+
+                buffer.extend([b'a'; 10]);
+                buffer.extend([b'z'; 10]);
+
+                assert!(codec.decode(&mut buffer).unwrap().is_none());
+
+                assert_eq!(&codec.buffer[..=9], &[b'a'; 10]);
+                assert_eq!(&codec.buffer[10..], &[b'z'; 6]);
+
+                assert_eq!(&buffer[..=9], &[b'a'; 10]);
+                assert_eq!(&buffer[10..], &[b'z'; 10]);
+            }
+
             mod test_iac {
                 use super::*;
                 use crate::constants::ECHO;


### PR DESCRIPTION
When encoding a TelnetEvent::Message, it guarantees a \r\n ending to all of its output, but that isn't always desirable. Add a new event called TelnetEvent::RawMessage that acts like a ::Message, but does not add the \r\n.

Incoming events never decode to ::RawMessage. It's intended for encoding outgoing messages only.


I added this today because I need this behavior for my project, but I'm not sure what your thoughts are on it, since it adds a new `TelnetEvent`. I haven't added tests yet because I want to make sure we're aligned on api / need first.