### PR TITLE
Mark TelnetOption as Hash

### DIFF
--- a/src/option.rs
+++ b/src/option.rs
@@ -4,7 +4,7 @@ use crate::constants::{
 };
 
 /// Represents all Telnet options supported by Nectar.
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum TelnetOption {
     /// Echo a message back to the other side
     Echo,


### PR DESCRIPTION
Hi,

I forgot to add this as a part of yesterdays PR but I'd like TelnetOption to be Hash. That way I can do a HashMap<TelnetOption, State> to keep track of what my client currently thinks we're doing.

 